### PR TITLE
remove operatorhub and add private repo stuffs and changed the defaul…

### DIFF
--- a/helm/openshift-gitops/templates/gitops-private-repo.yml
+++ b/helm/openshift-gitops/templates/gitops-private-repo.yml
@@ -9,4 +9,4 @@ stringData:
   type: git
   url: {{ .Values.gitRepoTemplate.url }}
   insecure: "true"
-  sshPrivateKey: {{ .Values.gitRepoTemplate.sshPrivateKey | b64enc}}
+  sshPrivateKey: {{ .Values.gitRepoTemplate.sshPrivateKey | quote }

--- a/helm/openshift-gitops/templates/operatorhub.yaml
+++ b/helm/openshift-gitops/templates/operatorhub.yaml
@@ -1,6 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: OperatorHub
-metadata:
-  name: cluster
-spec:
-  disableAllDefaultSources: true

--- a/helm/openshift-gitops/values.yaml
+++ b/helm/openshift-gitops/values.yaml
@@ -5,7 +5,7 @@ gitOps:
 
 gitRepoTemplate:
   # The URL of the repository setup in the Ansible step.
-  url: git@<ip of host>:repos
+  url: git@<ip of host>:repos/ocp4-disconnected-config
   # The SSH key of the user that ran the Ansible step, used to connect to the git repo
   sshPrivateKey: |
     -----BEGIN OPENSSH PRIVATE KEY-----


### PR DESCRIPTION
…t url for gitRepoTemplate

Modified templates/gitops-private-repo.yml from base64 encoding to quoting to make it work.
Removed operatorhub template
and added /ocp4-disconnected-config to the default values.yml